### PR TITLE
open the email in grunt connect task

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function (grunt) {
          */
         connect: {
             options: {
-                open: true,
+                open: '<%= paths.devDomain %>/<%= paths.email %>',
                 hostname: 'localhost',
                 port: 8000,
                 livereload: 35729


### PR DESCRIPTION
The connect and live reload tasks were just opening the directory and relying on the file being named "index.html" for it to be served by the watch task. Instead use the values specified in the config so you can use live reload on files with names other than index.html.
